### PR TITLE
Feature/move tasks on column deletion

### DIFF
--- a/src/components/Column.jsx
+++ b/src/components/Column.jsx
@@ -2,33 +2,33 @@ import { React, useState } from "react";
 import Task from "./Task";
 import AddTask from "./AddTask";
 import styles from "../styling/Column.module.css";
-import { useSelector, useDispatch } from "react-redux";
-import { removeColumn } from "../features/columns/columnSlice";
+import { useSelector } from "react-redux";
 import { MdOutlineDeleteForever as DeleteBtn } from "react-icons/md";
 import ConfirmDeletionModal from "./ConfirmDeletionModal";
 
-const Column = ({ columnId, columnIndex, title }) => {
+const Column = ({ columnId, title }) => {
   const [showModal, setShowModal] = useState(false);
   const tasks = useSelector((state) => state.allTaskReducer.tasks);
-  const dispatch = useDispatch();
-  const ConfirmDeltion = () => {
+  const ConfirmDeletion = () => {
     setShowModal(true);
   };
   return (
     <div className={styles.column}>
       <div className={styles.titleContainer}>
         <h2 className={styles.title}>{title}</h2>
-        <DeleteBtn
-          className={styles.delete}
-          onClick={() => dispatch(removeColumn(columnId))}
-          // onClick={ConfirmDeltion}
-        />
+        <DeleteBtn className={styles.delete} onClick={ConfirmDeletion} />
       </div>
       {tasks.map((task) =>
         task.atColumnId === columnId ? <Task key={task.id} task={task} /> : null
       )}
       <AddTask columnId={columnId} />
-      {/* {showModal && <ConfirmDeletionModal />} */}
+      {showModal && (
+        <ConfirmDeletionModal
+          setShowModal={setShowModal}
+          columnId={columnId}
+          tasks={tasks}
+        />
+      )}
     </div>
   );
 };

--- a/src/components/ConfirmDeletionModal.jsx
+++ b/src/components/ConfirmDeletionModal.jsx
@@ -32,7 +32,6 @@ const ConfirmDeletionModal = ({
 
   const handleCloseModalWindow = () => {
     setShowModal(false);
-    console.log("test");
   };
   return (
     <>

--- a/src/components/ConfirmDeletionModal.jsx
+++ b/src/components/ConfirmDeletionModal.jsx
@@ -4,12 +4,7 @@ import { useDispatch } from "react-redux";
 import { removeTask } from "../features/tasks/taskSlice";
 import { removeColumn } from "../features/columns/columnSlice";
 
-const ConfirmDeletionModal = ({
-  setShowModal,
-  columnId,
-  tasks,
-  columnIndex,
-}) => {
+const ConfirmDeletionModal = ({ setShowModal, columnId, tasks }) => {
   const [keepTasks, setKeepTasks] = useState(false);
   const dispatch = useDispatch();
 
@@ -17,9 +12,7 @@ const ConfirmDeletionModal = ({
   const handleConfirmDelete = () => {
     dispatch(removeColumn(columnId));
     setShowModal(false);
-    const tasksToDelete = tasks.filter(
-      (task) => task.atColumnIndex === columnIndex
-    );
+    const tasksToDelete = tasks.filter((task) => task.atColumnId === columnId);
     tasksToDelete.forEach((task) => {
       dispatch(removeTask(task.id));
     });


### PR DESCRIPTION
A modal will now appear when trying to delete a column asking you wether or not you want to go through with it and if you wish to keep the tasks in the column.

Note that the checkbox for keeping tasks does NOT work as of now.