### PR TITLE
Feature/move tasks on column deletion

### DIFF
--- a/src/components/ConfirmDeletionModal.jsx
+++ b/src/components/ConfirmDeletionModal.jsx
@@ -6,6 +6,7 @@ import { removeColumn } from "../features/columns/columnSlice";
 
 const ConfirmDeletionModal = ({ setShowModal, columnId, tasks }) => {
   const [keepTasks, setKeepTasks] = useState(false);
+  const [columnIndex, setColumnIndex] = useState(0);
   const columns = useSelector((state) => state.allColumnReducer.columns);
   const dispatch = useDispatch();
 
@@ -31,7 +32,7 @@ const ConfirmDeletionModal = ({ setShowModal, columnId, tasks }) => {
       tasksToMove.forEach((taskToMove) => {
         const newTask = {
           ...taskToMove,
-          atColumnId: columns[0].id,
+          atColumnId: columns[columnIndex].id,
         };
         dispatch(addTask(newTask));
 
@@ -46,9 +47,16 @@ const ConfirmDeletionModal = ({ setShowModal, columnId, tasks }) => {
     }
   };
 
+  const changeIndex = () => {
+    setColumnIndex(1);
+  };
+
   //Changes state based on checkbox
   const handleCheckboxClick = (event) => {
     setKeepTasks(event.target.checked);
+    if (columns[columnIndex].id === columnId) {
+      changeIndex();
+    }
   };
 
   const handleCloseModalWindow = () => {

--- a/src/components/ConfirmDeletionModal.jsx
+++ b/src/components/ConfirmDeletionModal.jsx
@@ -60,7 +60,6 @@ const ConfirmDeletionModal = ({ setShowModal, columnId, tasks }) => {
   };
 
   const handleCloseModalWindow = () => {
-    console.log(columns[0]);
     setShowModal(false);
   };
   return (

--- a/src/components/ConfirmDeletionModal.jsx
+++ b/src/components/ConfirmDeletionModal.jsx
@@ -26,7 +26,7 @@ const ConfirmDeletionModal = ({ setShowModal, columnId, tasks }) => {
       dispatch(removeColumn(columnId));
       setShowModal(false);
 
-      //Copies tasks at moves them to column of index 0
+      //Copies tasks and moves them to column of index 0
       const tasksToMove = tasks.filter((task) => task.atColumnId === columnId);
       tasksToMove.forEach((taskToMove) => {
         const newTask = {
@@ -34,6 +34,7 @@ const ConfirmDeletionModal = ({ setShowModal, columnId, tasks }) => {
           atColumnId: columns[0].id,
         };
         dispatch(addTask(newTask));
+
         //Clean up by removing the moved tasks
         const tasksToDelete = tasks.filter(
           (task) => task.atColumnId === columnId

--- a/src/components/ConfirmDeletionModal.jsx
+++ b/src/components/ConfirmDeletionModal.jsx
@@ -1,21 +1,46 @@
 import React, { useState } from "react";
 import styles from "../styling/Column.module.css";
-import { useDispatch } from "react-redux";
-import { removeTask } from "../features/tasks/taskSlice";
+import { useDispatch, useSelector } from "react-redux";
+import { removeTask, addTask } from "../features/tasks/taskSlice";
 import { removeColumn } from "../features/columns/columnSlice";
 
 const ConfirmDeletionModal = ({ setShowModal, columnId, tasks }) => {
   const [keepTasks, setKeepTasks] = useState(false);
+  const columns = useSelector((state) => state.allColumnReducer.columns);
   const dispatch = useDispatch();
 
   //Filters tasks in column and sends them to the task slice for deletion
   const handleConfirmDelete = () => {
-    dispatch(removeColumn(columnId));
-    setShowModal(false);
-    const tasksToDelete = tasks.filter((task) => task.atColumnId === columnId);
-    tasksToDelete.forEach((task) => {
-      dispatch(removeTask(task.id));
-    });
+    if (keepTasks === false) {
+      dispatch(removeColumn(columnId));
+      setShowModal(false);
+      const tasksToDelete = tasks.filter(
+        (task) => task.atColumnId === columnId
+      );
+      tasksToDelete.forEach((task) => {
+        dispatch(removeTask(task.id));
+      });
+      //If user wants to keep their tasks
+    } else if (keepTasks === true) {
+      dispatch(removeColumn(columnId));
+      setShowModal(false);
+      //Copies tasks at moves them to column of index 0
+      const tasksToMove = tasks.filter((task) => task.atColumnId === columnId);
+      tasksToMove.forEach((taskToMove) => {
+        const newTask = {
+          ...taskToMove,
+          atColumnId: columns[0].id,
+        };
+        dispatch(addTask(newTask));
+        //Clean up by removing the moved tasks
+        const tasksToDelete = tasks.filter(
+          (task) => task.atColumnId === columnId
+        );
+        tasksToDelete.forEach((task) => {
+          dispatch(removeTask(task.id));
+        });
+      });
+    }
   };
 
   //Changes state based on checkbox
@@ -24,6 +49,7 @@ const ConfirmDeletionModal = ({ setShowModal, columnId, tasks }) => {
   };
 
   const handleCloseModalWindow = () => {
+    console.log(columns[0]);
     setShowModal(false);
   };
   return (

--- a/src/components/ConfirmDeletionModal.jsx
+++ b/src/components/ConfirmDeletionModal.jsx
@@ -20,10 +20,12 @@ const ConfirmDeletionModal = ({ setShowModal, columnId, tasks }) => {
       tasksToDelete.forEach((task) => {
         dispatch(removeTask(task.id));
       });
+
       //If user wants to keep their tasks
     } else if (keepTasks === true) {
       dispatch(removeColumn(columnId));
       setShowModal(false);
+
       //Copies tasks at moves them to column of index 0
       const tasksToMove = tasks.filter((task) => task.atColumnId === columnId);
       tasksToMove.forEach((taskToMove) => {


### PR DESCRIPTION
When confirming to keep tasks on column deletion they are now moved to the column at index 0 and deletes the old tasks from local storage.